### PR TITLE
Add the Marceline firmware Arduino example project

### DIFF
--- a/examples/firmware-marceline/firmware-marceline.ino
+++ b/examples/firmware-marceline/firmware-marceline.ino
@@ -1,0 +1,12 @@
+#include <Mirobot.h>
+
+Mirobot mirobot;
+
+void setup(){
+  mirobot.begin();
+  mirobot.enableSerial();
+}
+
+void loop(){
+  mirobot.loop();
+}


### PR DESCRIPTION
Add the Marceline firmware Arduino project so that it is clear
which Arduino project is for the Marceline robot.
The project is simply a copy of the Mirobot firmware-v2 example
project with only a name change from firmware-v2.ino to
firmware-marceline.ino.